### PR TITLE
reconnect if connection closed by maxcube

### DIFF
--- a/maxcube.js
+++ b/maxcube.js
@@ -261,8 +261,13 @@ module.exports = function(RED) {
       if(node.maxCube){
         node.log("Preparing new Maxcube events callback");
         node.maxCube.on('closed', function () {
-          node.log("Maxcube connection closed...");
           connected = false;
+          if(node.maxCube != null) {
+            node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
+            node.maxcubeConnect();
+          }
+          else
+            node.log("Maxcube connection closed...");
         });
         node.maxCube.on('error', function (e) {
           node.log("Error connecting to the cube.");
@@ -281,7 +286,9 @@ module.exports = function(RED) {
 
     node.on("close", function() {
       if(node.maxCube){
-        node.maxCube.close();
+        var maxCube = node.maxCube;
+        node.maxCube = null;
+        maxCube.close();
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-maxcube2",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "A node-red node to control the eQ-3 Max! Cube with maxcube2.js",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes that the newly added reconnect is not working properly when the connection is not lost, but gracefully closed by the MAX! Cube becuse of an idle timeout.