### PR TITLE
node status not updated after reconnect

### DIFF
--- a/maxcube.js
+++ b/maxcube.js
@@ -261,8 +261,13 @@ module.exports = function(RED) {
       if(node.maxCube){
         node.log("Preparing new Maxcube events callback");
         node.maxCube.on('closed', function () {
-          node.log("Maxcube connection closed...");
           connected = false;
+          if(node.maxCube != null) {
+            node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
+            node.maxcubeConnect();
+          }
+          else
+            node.log("Maxcube connection closed...");
         });
         node.maxCube.on('error', function (e) {
           node.log("Error connecting to the cube.");
@@ -281,7 +286,9 @@ module.exports = function(RED) {
 
     node.on("close", function() {
       if(node.maxCube){
-        node.maxCube.close();
+        var maxCube = node.maxCube;
+        node.maxCube = null;
+        maxCube.close();
       }
     });
 

--- a/maxcube.js
+++ b/maxcube.js
@@ -27,21 +27,18 @@ module.exports = function(RED) {
     }
 
     //handle status icons
-    var maxCube = node.serverConfig.maxCube;
-    if(maxCube){
-      maxCube.on('closed', function () {
-        node.status({fill:"red",shape:"ring",text:"disconnected"});
-      });
+    node.serverConfig.on('closed', function () {
+      node.status({fill:"red",shape:"ring",text:"disconnected"});
+    });
 
-      maxCube.on('connected', function () {
-        node.status({fill:"green",shape:"dot",text:"connected"});
-      });
+    node.serverConfig.on('connected', function () {
+      node.status({fill:"green",shape:"dot",text:"connected"});
+    });
 
-      maxCube.on('error', function (err) {
-        node.log(err);
-        node.status({fill:"red",shape:"dot",text:"Error: "+err});
-      });
-    }
+    node.serverConfig.on('error', function (err) {
+      node.log(err);
+      node.status({fill:"red",shape:"dot",text:"Error: "+err});
+    });
 
     return true;
   }
@@ -261,6 +258,7 @@ module.exports = function(RED) {
       if(node.maxCube){
         node.log("Preparing new Maxcube events callback");
         node.maxCube.on('closed', function () {
+          node.emit('closed');
           connected = false;
           if(node.maxCube != null) {
             node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
@@ -270,6 +268,7 @@ module.exports = function(RED) {
             node.log("Maxcube connection closed...");
         });
         node.maxCube.on('error', function (e) {
+          node.emit('error', e);
           node.log("Error connecting to the cube.");
           node.log(JSON.stringify(e));
           connected = false;
@@ -278,8 +277,9 @@ module.exports = function(RED) {
           node.maxcubeConnect();
         });
         node.maxCube.on('connected', function () {
-            node.log("Maxcube connected");
-            connected = true;
+          node.emit('connected');
+          node.log("Maxcube connected");
+          connected = true;
         });
       }
     };


### PR DESCRIPTION
This PR fixes that the status of the nodes is not updated anymore after a reconnect because the reference to "maxCube" is lost, because it is recreated.

Instead of the nodes referencing maxCube directly, they add listeners to the server instance now to be independent.

This branch is created from my former branch / PR which fixes the reconnect issue, you might want to look into my former PR first.