### PR TITLE
Don't endless loop while trying to reconnect

### DIFF
--- a/maxcube.js
+++ b/maxcube.js
@@ -261,8 +261,8 @@ module.exports = function(RED) {
           node.emit('closed');
           connected = false;
           if(node.maxCube != null) {
-            node.log("Maxcube connection closed unexpectedly... will try to reconnect.");
-            node.maxcubeConnect();
+            node.log("Maxcube connection closed unexpectedly... will try to reconnect in one second.");
+            setTimeout( node.maxcubeConnect, 1000 );
           }
           else
             node.log("Maxcube connection closed...");
@@ -273,8 +273,8 @@ module.exports = function(RED) {
           node.log(JSON.stringify(e));
           connected = false;
           //force node to init connection if not available
-          node.log("Maxcube was disconnected... will try to reconnect.");
-          node.maxcubeConnect();
+          node.log("Maxcube was disconnected... will try to reconnect in one second.");
+          setTimeout( node.maxcubeConnect, 1000 );
         });
         node.maxCube.on('connected', function () {
           node.emit('connected');

--- a/maxcube.js
+++ b/maxcube.js
@@ -241,6 +241,7 @@ module.exports = function(RED) {
     node.maxcubeConnect = function(){
 
       if(node.maxCube){
+         node.maxCube.removeAllListeners('closed');
          node.maxCube.close();
          node.maxCube = undefined;
       }


### PR DESCRIPTION
Fixes #10

While trying to reconnect, maxcube.close() is called, which emits a 'closed' event, which triggers another reconnect, again calling maxbube.close(), which...endless loops but never actually reconnects.

By removing all 'closed' event handlers from maxcube before closing it, the event handler is not called again and no endless loop happens.

Also deferred reconnection by 1 second to reduce load.