### PR TITLE
Added reset command to output node

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ node-red-contrib-maxcube2 is a fork of https://github.com/ivesdebruycker/node-re
 - Node to query devices configurations
 - Set mode to all devices with a single payload ({"mode" : "AUTO"} without rf_address)
 - Output devices data as single message or separeted messages
+- Send a reset command to devices not reacting to other commands
 - I'm planning add some additional features like schedule settings
 
 The old API didn't change currently so it's a drop-in replacement.
@@ -149,7 +150,7 @@ or as a single message with the following structure:
 ```
 
 ### maxcube (output)of a device
-A node to set the temperature and/or the mode of a device.
+A node to set the temperature and/or the mode of a device and/or reset a device.
 Valid modes are "AUTO", "MANUAL", "BOOST" and "VACATION".
 
 Accepts messages with payload of type object with following structure:
@@ -181,4 +182,19 @@ VACATION on all devices until specific date (ISO 8601)
   "mode":"VACATION",
   "untilDate" : "2019-06-20T10:00:00Z"
 }
+```
+Reset a device
+```
+{
+  "rf_address": "0abc12",
+  "reset": true
+}
+```
+Reset all devices
+```
+{
+  "reset": true
+}
+```
+The reset field can also be added to any of the above commands to issue a reset command before sending the temperature update.
 ```

--- a/maxcube.html
+++ b/maxcube.html
@@ -28,7 +28,8 @@
       <pre>{
   "rf_address": "0abc12",
   "degrees": 20,
-  "mode": "MANUAL"
+  "mode": "MANUAL",
+  "reset": false
 }</pre>
     </p>
 </script>

--- a/maxcube.js
+++ b/maxcube.js
@@ -110,7 +110,6 @@ module.exports = function(RED) {
 
       var resetDevice = function( rf_address ){
         // Timeout after 30 seconds
-        node.log( 'Calling resetError for ' + rf_address );
         return maxCube.resetError( rf_address, 30000 ).then( function (success) {
           node.status( { fill: 'green', shape: 'dot', text: 'last msg: reset ' + JSON.stringify(rf_address) } );
           sendCommStatus(node, success, rf_address);
@@ -118,7 +117,7 @@ module.exports = function(RED) {
             node.log( 'Device reset: ' + rf_address );
             return true;
           } else {
-            node.log( 'Reset command for device ' + rf_address + ' discarded by cube. Maybe duty cycle exceeded.' );
+            node.warn( 'Reset command for device ' + rf_address + ' discarded by cube. Maybe duty cycle exceeded.' );
             throw new Error( 'Reset command discarded.' );
           }
         } ).catch( function( e ) {
@@ -147,16 +146,13 @@ module.exports = function(RED) {
         }
         
         if( payload.reset ){
-          node.log( 'Calling resetDevice for ' + rf_address );
           return resetDevice( rf_address ).then( function( success ) {
-            node.log( 'Calling setTempFunc for ' + rf_address );
             return setTempFunc();
           } ).catch( function( err ) {
             // do nothing, everything has been done already
             // but still catch the error, because uncaught errors are bad
           } );
         } else {
-          node.log( 'Calling setTempFunc for ' + rf_address );
           return setTempFunc();
         }
       };


### PR DESCRIPTION
Sometimes devices need a reset before they accept commands.

The original SW sends that reset before setting the temperature. Not sure if it sends the reset all the time or only when required. But I somehow think that they might have taken the simple solution and just send it all the time.

This change adds support for the reset command to the output node. The underlying library supported that command anyway.

Reset can be send as a separate command or before a temperature command.